### PR TITLE
Added DataHub to "Nodes and clients" page

### DIFF
--- a/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
+++ b/src/content/developers/docs/nodes-and-clients/nodes-as-a-service/index.md
@@ -85,6 +85,18 @@ Here is a list of some of the most popular Ethereum node providers, feel free to
     - Bring your cloud
     - Pay-per-hour pricing
     - Direct 24/7 support
+- [**DataHub**](https://datahub.figment.io)
+  - [Docs](https://docs.figment.io/)
+  - Features
+    - Free tier option with 3,000,000 reqs/month
+    - RPC and WSS endpoints
+    - Dedicated full and archive nodes
+    - Auto-Scaling (Volume Discounts)
+    - Free archival data
+    - Service Analytics
+    - Dashboard
+    - Direct 24/7 Support
+    - Pay in Crypto (Enterprise)
 - [**GetBlock**](https://getblock.io/)
   - [Docs](https://getblock.io/docs/get-started/authentication-with-api-key/)
   - Features


### PR DESCRIPTION
Added DataHub under the "Popular node services" section on "Nodes and clients" page.

## Description

DataHub provides access to the RPC and REST APIs of our supported protocols including Ethereum for both the latest mainnets and testnets. In this PR I've updated the "Popular node services" section on "Nodes and clients" page to add the DataHub as one of the node providers in this list.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
